### PR TITLE
Make header flex and spaced between

### DIFF
--- a/interface/components/header/index.styl
+++ b/interface/components/header/index.styl
@@ -7,6 +7,8 @@ tf-header
   box-sizing border-box
   z-index 100000
   box-shadow 0 0 3px rgba(black, 0.3)
+  display flex
+  justify-content space-between
 
   .loader
     position absolute


### PR DESCRIPTION
closes #3 

## Changes
  - Make header display flex and space between

## Demo
<img width="1440" alt="screen shot 2018-09-21 at 11 20 31 pm" src="https://user-images.githubusercontent.com/17058138/45912787-f848f180-bdf4-11e8-810f-f7b5eba9b446.png">
<img width="1007" alt="screen shot 2018-09-21 at 11 20 37 pm" src="https://user-images.githubusercontent.com/17058138/45912788-f848f180-bdf4-11e8-8093-cd64af5af9b4.png">
