### PR TITLE
Fix candidate pane: overflow

### DIFF
--- a/interface/components/candidates/index.styl
+++ b/interface/components/candidates/index.styl
@@ -2,12 +2,9 @@ tf-candidates
   position relative
   display block
   size 100%
-  overflow hidden
-  overflow-y scroll
+  overflow scroll
 
   .wrapper
-    overflow hidden
-    position absolute
     right 10px
     width 100%
 


### PR DESCRIPTION
closes #7 

## Changes
  - When tf-candidate wrapper's width > candidate pane width, set overflow scrollable
  - Remove position absolute for the candidate wrapper

## Demo
<img width="1089" alt="screen shot 2018-10-01 at 10 17 09 am" src="https://user-images.githubusercontent.com/17058138/46294198-3798e000-c563-11e8-9cc7-60118aa0d839.png">
