### PR TITLE
Transform: Allow K-Order, Standardize, Normalize

### DIFF
--- a/engine/labels.json
+++ b/engine/labels.json
@@ -5,7 +5,7 @@
 
   "LOG" : "log",
   "K_ORDER_DIFFERENCE" : "k_order_difference",
-  "STUDENTIZED" : "studentized",
-  "NORMALIZED" : "normalized",
+  "STANDARDIZE" : "standardize",
+  "RESCALE" : "rescale",
   "DELETE": "delete"
 }

--- a/engine/matrix/Matrix.js
+++ b/engine/matrix/Matrix.js
@@ -707,6 +707,32 @@ class Matrix {
   }
 
   /**
+   * Get the mean in matrix
+   */
+  mean() {
+    let accum = 0, i;
+
+    for (i = 0; i < this[_data].length; i += 1) {
+      accum += this[_data][i];
+    }
+    return accum / this[_data].length;
+  }
+
+  /**
+   * Get the standard deviation in matrix
+   */
+  std() {
+    let mean = this.mean();
+    let len = this[_data].length;
+    let diff = this[_data].map((d) => Math.pow(d - mean, 2))
+    let i, accum = 0;
+    for (i = 0; i < diff.length; i += 1) {
+      accum += diff[i];
+    }
+    return Math.sqrt(accum/len)
+  }
+
+  /**
    * @property {Matrix<n,m>} T The transposition of the matrix
    */
   get T() {

--- a/engine/matrix/Matrix.js
+++ b/engine/matrix/Matrix.js
@@ -92,7 +92,7 @@ class Matrix {
    * @param {number}                    m     Number of rows
    * @param {Float64Array | number[][]} stuff Items to populate the matrix
    */
-  constructor(m, n, stuff) {
+  constructor(m, n, stuff, skip_NaN = false) {
     if (m instanceof Matrix) {
       return m;
     }
@@ -118,7 +118,7 @@ class Matrix {
     for(let i = 0; i < n; i++){
       // j: iterate over rows
       for(let j = 0; j < m; j++){
-        if(isNaN(stuff[j*n + i])){
+        if(!skip_NaN && isNaN(stuff[j*n + i])) {
           valid_columns[i] = false;
           valid_column_count -= 1;
           break;

--- a/engine/matrix/Matrix.js
+++ b/engine/matrix/Matrix.js
@@ -707,32 +707,6 @@ class Matrix {
   }
 
   /**
-   * Get the mean in matrix
-   */
-  mean() {
-    let accum = 0, i;
-
-    for (i = 0; i < this[_data].length; i += 1) {
-      accum += this[_data][i];
-    }
-    return accum / this[_data].length;
-  }
-
-  /**
-   * Get the standard deviation in matrix
-   */
-  std() {
-    let mean = this.mean();
-    let len = this[_data].length;
-    let diff = this[_data].map((d) => Math.pow(d - mean, 2))
-    let i, accum = 0;
-    for (i = 0; i < diff.length; i += 1) {
-      accum += diff[i];
-    }
-    return Math.sqrt(accum/len)
-  }
-
-  /**
    * @property {Matrix<n,m>} T The transposition of the matrix
    */
   get T() {

--- a/engine/model/Model.js
+++ b/engine/model/Model.js
@@ -94,6 +94,11 @@ class Model extends CacheMixin(Observable) {
             // this[_data][data_label] = this[_data][data_label].appendM(transform_col);
             this.setData(this[_data][data_label].appendM(transform_col), data_label)
             break;
+          case (K_ORDER_DIFFERENCE):
+            var transform_col = statistics.compute(label, {X: col})
+            // this[_data][data_label] = this[_data][data_label].appendM(transform_col);
+            this.setData(this[_data][data_label].appendM(transform_col), data_label)
+            break;
           default:
             break;
         }

--- a/engine/model/Model.js
+++ b/engine/model/Model.js
@@ -76,7 +76,7 @@ class Model extends CacheMixin(Observable) {
     return this;
   }
 
-  transformColumn(label, index) {
+  transformColumn(label, index, k=undefined) {
     if (index === undefined || isNaN(index)) {
       return this;
     }
@@ -98,7 +98,7 @@ class Model extends CacheMixin(Observable) {
             this.setData(this[_data][data_label].appendM(transform_col), data_label)
             break;
           case (K_ORDER_DIFFERENCE):
-            var transform_col = statistics.compute(label, {X: col})
+            var transform_col = statistics.compute(label, {X: col, k: k})
             // this[_data][data_label] = this[_data][data_label].appendM(transform_col);
             this.setData(this[_data][data_label].appendM(transform_col), data_label)
             break;

--- a/engine/model/Model.js
+++ b/engine/model/Model.js
@@ -12,8 +12,8 @@ const {
   VALIDATION_LABEL,
   LOG,
   K_ORDER_DIFFERENCE,
-  STUDENTIZED,
-  NORMALIZED,
+  STANDARDIZE,
+  RESCALE,
   DELETE,
 }   = require('../labels.json');
 
@@ -99,6 +99,21 @@ class Model extends CacheMixin(Observable) {
             break;
           case (K_ORDER_DIFFERENCE):
             var transform_col = statistics.compute(label, {X: col, k: k})
+            // this[_data][data_label] = this[_data][data_label].appendM(transform_col);
+            this.setData(this[_data][data_label].appendM(transform_col), data_label)
+            break;
+          case (STANDARDIZE):
+            var mean = statistics.compute("mean", {X: col})
+            var std = statistics.compute("std", {X: col, mean: mean})
+            console.log("Mean", mean);
+            console.log("Std", std)
+            var transform_col = statistics.compute(label, {X: col, mean: mean, std: std})
+            // this[_data][data_label] = this[_data][data_label].appendM(transform_col);
+            this.setData(this[_data][data_label].appendM(transform_col), data_label)
+            break;
+          case (RESCALE):
+            var rms = statistics.compute("RMS", {X: col});
+            var transform_col = statistics.compute(label, {X: col, RMS: rms});
             // this[_data][data_label] = this[_data][data_label].appendM(transform_col);
             this.setData(this[_data][data_label].appendM(transform_col), data_label)
             break;

--- a/engine/statistics/definitions.js
+++ b/engine/statistics/definitions.js
@@ -87,15 +87,33 @@ module.exports = [
   
   Statistic('log', ["X"], ({X}) => X.log()),
 
-  Statistic('standardize', ["X"], ({X}) => {
+  Statistic('mean', ["X"], ({X}) => {
+    return X.data.reduce((total, c) => total += c, 0) / X.data.length
+  }),
+
+  Statistic('std', ["X", "mean"], ({X, mean}) => {
+    let diff = X.data.map((d) => Math.pow(d - mean, 2))
+    let diff_total = diff.reduce((total, c) => total += c, 0)
+    return Math.sqrt(diff_total / X.data.length)
+  }),
+
+  Statistic('standardize', ["X", "mean", "std"], ({X, mean, std}) => {
     let standardize = X.clone();
-    standardize.data.set(standardize.data.map((d) => d - X.mean() / X.std()));
+    standardize.data.set(standardize.data.map((d) => (d - mean) / std));
     return standardize;
   }),
 
-  Statistic('rescale', ["X"], ({X}) => {
+  Statistic('RMS', ["X"], ({X}) => {
+    let rms = X.clone();
+    let SS = rms.data
+      .map(r => Math.pow(r, 2))
+      .reduce((total, xi) => total += xi, 0);
+    return Math.sqrt(SS/ rms.data.length);
+  }),
+
+  Statistic('rescale', ["X", "RMS"], ({X, RMS}) => {
     let rescale = X.clone();
-    rescale.data.set(rescale.data.map((d) => d / X.std()));
+    rescale.data.set(rescale.data.map((d) => d / RMS));
     return rescale;
   }),
 

--- a/engine/statistics/definitions.js
+++ b/engine/statistics/definitions.js
@@ -85,5 +85,17 @@ module.exports = [
   Statistic('pF', ['F', 'np', 'nd'],
     ({F, np, nd}) => Math.max(dist.pf(Math.abs(F), np, nd - np) - 1e-15, 0)),
   
-  Statistic('log', ["X"], ({X}) => X.log())
+  Statistic('log', ["X"], ({X}) => X.log()),
+
+  Statistic('standardize', ["X"], ({X}) => {
+    let standardize = X.clone();
+    standardize.data.set(standardize.data.map((d) => d - X.mean() / X.std()));
+    return standardize;
+  }),
+
+  Statistic('rescale', ["X"], ({X}) => {
+    let rescale = X.clone();
+    rescale.data.set(rescale.data.map((d) => d / X.std()));
+    return rescale;
+  }),
 ];

--- a/engine/statistics/definitions.js
+++ b/engine/statistics/definitions.js
@@ -99,5 +99,20 @@ module.exports = [
     return rescale;
   }),
 
-  Statistic('k_order_difference')
+  Statistic('k_order_difference', ["X", "k"], ({X, k}) => {
+    let k_order_func = (data, k) => {
+      if (k == 1) {
+        return data.map((d, idx) => idx < k ? null : d - data[idx - 1]);
+      } else {
+        k_1_order = k_order_func(data, k - 1);
+        return data.map((_, idx) => idx < k ? null : k_1_order[idx] - k_1_order[idx - 1]);
+      }
+    };
+    if (!k || isNaN(k)) {
+      return X;
+    }
+    let k_order = X.clone();
+    k_order.data.set(k_order_func(k_order.data, k));
+    return k_order;
+  })
 ];

--- a/engine/statistics/definitions.js
+++ b/engine/statistics/definitions.js
@@ -98,4 +98,6 @@ module.exports = [
     rescale.data.set(rescale.data.map((d) => d / X.std()));
     return rescale;
   }),
+
+  Statistic('k_order_difference')
 ];

--- a/engine/statistics/metadata.json
+++ b/engine/statistics/metadata.json
@@ -48,5 +48,11 @@
   { "id": "mean", "show": false },
   { "id": "weights", "show": false },
 
-  { "id": "log", "show": false }
+  { "id": "log", "show": false },
+  { "id": "mean", "show": false },
+  { "id": "std", "show": false },
+  { "id": "standardize", "show": false },
+  { "id": "RMS", "show": false },
+  { "id": "rescale", "show": false },
+  { "id": "k_order_difference", "show": false }
 ]

--- a/engine/worker/engine-worker.js
+++ b/engine/worker/engine-worker.js
@@ -10,8 +10,8 @@ const {
   FIT_LABEL, CROSS_LABEL, VALIDATION_LABEL,
   LOG,
   K_ORDER_DIFFERENCE,
-  STUDENTIZED,
-  NORMALIZED,
+  STANDARDIZE,
+  RESCALE,
   DELETE,
 } = require('../labels.json');
 
@@ -157,7 +157,7 @@ onmessage = function (e) {
       m.subset(data.label, data.start, data.end);
       break;
 
-    case 'tranformData':
+    case 'transformData':
       switch (data.label) {
         case (Transformation.Transform.delete):
           m.transformColumn(DELETE, data.index);
@@ -168,11 +168,11 @@ onmessage = function (e) {
         case (Transformation.Transform.k_order_diff):
           m.transformColumn(K_ORDER_DIFFERENCE, data.index, data.k);
           break;
-        case (Transformation.Transform.studentize):
-          m.transformColumn(STUDENTIZED, data.index);
+        case (Transformation.Transform.standardize):
+          m.transformColumn(STANDARDIZE, data.index);
           break;
-        case (Transformation.Transform.normalize):
-          m.transformColumn(NORMALIZED, data.index);
+        case (Transformation.Transform.rescale):
+          m.transformColumn(RESCALE, data.index);
           break;
         default:
           break;

--- a/engine/worker/engine-worker.js
+++ b/engine/worker/engine-worker.js
@@ -163,6 +163,16 @@ onmessage = function (e) {
           m.transformColumn(DELETE, data.index);
         case (Transformation.Transform.log):
           m.transformColumn(LOG, data.index);
+          break;
+        case (Transformation.Transform.k_order_diff):
+          m.transformColumn(K_ORDER_DIFFERENCE, data.index);
+          break;
+        case (Transformation.Transform.studentize):
+          m.transformColumn(STUDENTIZED, data.index);
+          break;
+        case (Transformation.Transform.normalize):
+          m.transformColumn(NORMALIZED, data.index);
+          break;
         default:
           break;
       }

--- a/interface/adapter/worker.coffee
+++ b/interface/adapter/worker.coffee
@@ -76,12 +76,11 @@ module.exports = new class WorkerAdapter extends ME
   transformLog: ( x ) ->
     @post("transformData", { label: Transformation.Transform.log, index: x })
   kOrderTransform: ( x ) ->
-    len_x = x.length
-    if len_x > 0
+    if x
       @post("transformData", {
         label: Transformation.Transform.k_order_diff,
-        index: x[0],
-        k: x[len_x - 1]
+        index: x.index,
+        k: x.k
       })
   transformStandardize: ( x ) ->
     @post("transformData", { label: Transformation.Transform.standardize, index: x })

--- a/interface/adapter/worker.coffee
+++ b/interface/adapter/worker.coffee
@@ -77,6 +77,11 @@ module.exports = new class WorkerAdapter extends ME
     len_x = x.length
     @post("tranformData", { label: x[0], index: x[len_x - 1] })
 
+  kOrderTransform: ( x ) ->
+    len_x = x.length
+    if len_x > 0
+      @post("tranformData", { index: x[0], k: x[len_x - 1] })
+
   requestStatisticsMetadata: ( ) ->
     @post "getStatisticsMetadata"
 

--- a/interface/adapter/worker.coffee
+++ b/interface/adapter/worker.coffee
@@ -71,22 +71,22 @@ module.exports = new class WorkerAdapter extends ME
   removeTerm: ( x ) ->
     @post "removeTerm", x
   
-  tranformData: ( x ) ->
-    # Doing len_x - 1 and not x[1] because sometimes the label index and index value can be the same
-    # Ex: Transform index 1 with log (log is 1 in transform/label.json)
-    # So x is [1] since the object is {1: true}
-    len_x = x.length
-    if len_x > 0
-      @post("tranformData", { label: x[0], index: x[len_x - 1] })
-
+  transformDelete: ( x ) ->
+    @post("transformData", { label: Transformation.Transform.delete, index: x })
+  transformLog: ( x ) ->
+    @post("transformData", { label: Transformation.Transform.log, index: x })
   kOrderTransform: ( x ) ->
     len_x = x.length
     if len_x > 0
-      @post("tranformData", {
+      @post("transformData", {
         label: Transformation.Transform.k_order_diff,
         index: x[0],
         k: x[len_x - 1]
       })
+  transformStandardize: ( x ) ->
+    @post("transformData", { label: Transformation.Transform.standardize, index: x })
+  transformRescale: ( x ) ->
+    @post("transformData", { label: Transformation.Transform.rescale, index: x })
 
   requestStatisticsMetadata: ( ) ->
     @post "getStatisticsMetadata"

--- a/interface/adapter/worker.coffee
+++ b/interface/adapter/worker.coffee
@@ -1,3 +1,4 @@
+Transformation = require("../components/transform/label.json")
 
 SILENT_MESSAGE_TYPES = [ "progress" ]
 
@@ -81,7 +82,11 @@ module.exports = new class WorkerAdapter extends ME
   kOrderTransform: ( x ) ->
     len_x = x.length
     if len_x > 0
-      @post("tranformData", { index: x[0], k: x[len_x - 1] })
+      @post("tranformData", {
+        label: Transformation.Transform.k_order_diff,
+        index: x[0],
+        k: x[len_x - 1]
+      })
 
   requestStatisticsMetadata: ( ) ->
     @post "getStatisticsMetadata"

--- a/interface/components/Model.coffee
+++ b/interface/components/Model.coffee
@@ -97,10 +97,16 @@ CTRL =
     [ {}          , WRAP_O                            , UNWRAP_O ]
   # Key is the type of transformation
   # Value has no value, just has to be true
-  tranformData:
-    [ undefined   , SEND("tranformData", object2array)      , UNWRAP_O ]
+  transformDelete:
+    [ undefined   , SEND("transformDelete", Number)   , UNWRAP_O ]
+  transformLog:
+    [ undefined   , SEND("transformLog", Number)      , UNWRAP_O ]
   kOrderTransform:
     [ undefined   , SEND("kOrderTransform", object2array)   , UNWRAP_O ]
+  transformStandardize:
+    [ undefined   , SEND("transformStandardize", Number), UNWRAP_O ]
+  transformRescale:
+    [ undefined   , SEND("transformRescale", Number)  , UNWRAP_O ]
 
 module.exports = class Model
 
@@ -198,8 +204,11 @@ module.exports = class Model
         @data_cross(data.cross)
         # if (@data_validation())
         @data_validation(data.validation)
-        @tranformData(undefined)
+        @transformLog(undefined)
+        @transformDelete(undefined)
         @kOrderTransform(undefined)
+        @transformStandardize(undefined)
+        @transformRescale(undefined)
         adapter.subscribeToChanges()
         # TODO (justint): Handle case if add cross and validation data after transform, need to track all transformation and propgate to new data
       , 100

--- a/interface/components/Model.coffee
+++ b/interface/components/Model.coffee
@@ -27,6 +27,8 @@ object2array = ( exps ) ->
   Number key for key, value of ko.unwrap exps \
   when ko.unwrap value
 
+object2object = ( exps ) -> exps
+
 CTRL =
   id:
     [ "model"     , WRAP_O                            , UNWRAP ]
@@ -102,7 +104,7 @@ CTRL =
   transformLog:
     [ undefined   , SEND("transformLog", Number)      , UNWRAP_O ]
   kOrderTransform:
-    [ undefined   , SEND("kOrderTransform", object2array)   , UNWRAP_O ]
+    [ undefined   , SEND("kOrderTransform", object2object), UNWRAP_O ]
   transformStandardize:
     [ undefined   , SEND("transformStandardize", Number), UNWRAP_O ]
   transformRescale:

--- a/interface/components/Model.coffee
+++ b/interface/components/Model.coffee
@@ -99,6 +99,8 @@ CTRL =
   # Value has no value, just has to be true
   tranformData:
     [ undefined   , SEND("tranformData", object2array)      , UNWRAP_O ]
+  kOrderTransform:
+    [ undefined   , SEND("kOrderTransform", object2array)   , UNWRAP_O ]
 
 module.exports = class Model
 
@@ -197,6 +199,7 @@ module.exports = class Model
         # if (@data_validation())
         @data_validation(data.validation)
         @tranformData(undefined)
+        @kOrderTransform(undefined)
         adapter.subscribeToChanges()
         # TODO (justint): Handle case if add cross and validation data after transform, need to track all transformation and propgate to new data
       , 100

--- a/interface/components/grid/index.coffee
+++ b/interface/components/grid/index.coffee
@@ -54,13 +54,13 @@ ko.components.register "tf-grid",
     
     @canDeleteTransformColumn = ( index ) ->
       transformColumns = Object.values(@transform_columns())
-      model_terms = @result().terms
       # The index must be a value in transform_columns. It is a transformation of the key
       # And the index must not be a key in transform_columns where value is not undefined.
       # If the value for index key is not undefined, means it has another transform column is dependent on it
       return transformColumns.includes(index) &&
         !@transform_columns()[index] &&
-        !model_terms.find((term) ->
+        @result() &&
+        !@result().terms.find((term) ->
           term.term.find((t) -> t.index == index)
         )
 

--- a/interface/components/grid/index.coffee
+++ b/interface/components/grid/index.coffee
@@ -79,10 +79,7 @@ ko.components.register "tf-grid",
       cols = @cols()
       cols.splice(index, 1)
       model.columns(cols)
-      model.tranformData({
-        "#{Transformation.Transform.delete}": true,
-        "#{index}": true
-      })
+      model.transformDelete(index)
 
     @showHideColumn = ( shouldHide, index ) ->
       oldCols = @hiddenColumns()

--- a/interface/components/transform/index.coffee
+++ b/interface/components/transform/index.coffee
@@ -56,14 +56,17 @@ ko.components.register "tf-transform",
       link_transform_column(index, transform_col.index)
       @close()
     
-    @k_order_diff = ( index ) ->
+    @k_order_diff = ( index, k = 1 ) ->
       transform_col = gen_column(
         Transformation.K_ORDER_DIFFERENCE,
         index
       )
       cols = columns()
       cols.push(transform_col)
-      model.tranformData({ 1: Transformation.K_ORDER_DIFFERENCE, 2: index })
+      model.kOrderTransform({
+        "#{index}": true,
+        "#{k}": true
+      })
       # Need to append new column name and connect new column with existing column
       model.columns(cols)
       link_transform_column(index, transform_col.index)

--- a/interface/components/transform/index.coffee
+++ b/interface/components/transform/index.coffee
@@ -47,10 +47,7 @@ ko.components.register "tf-transform",
       )
       cols = columns()
       cols.push(transform_col)
-      model.tranformData({
-        "#{Transformation.Transform.log}": true,
-        "#{index}": true
-      })
+      model.transformLog(index)
       # Need to append new column name and connect new column with existing column
       model.columns(cols)
       link_transform_column(index, transform_col.index)
@@ -72,27 +69,27 @@ ko.components.register "tf-transform",
       link_transform_column(index, transform_col.index)
       @close()
 
-    @studentize = ( index ) ->
+    @standardize = ( index ) ->
       transform_col = gen_column(
-        Transformation.STUDENTIZED,
+        Transformation.STANDARDIZE,
         index
       )
       cols = columns()
       cols.push(transform_col)
-      model.tranformData({ 1: Transformation.STUDENTIZED, 2: index })
+      model.transformStandardize(index)
       # Need to append new column name and connect new column with existing column
       model.columns(cols)
       link_transform_column(index, transform_col.index)
       @close()
 
-    @normalize = ( index ) ->
+    @rescale = ( index ) ->
       transform_col = gen_column(
-        Transformation.NORMALIZED,
+        Transformation.RESCALE,
         index
       )
       cols = columns()
       cols.push(transform_col)
-      model.tranformData({ 1: Transformation.NORMALIZED, 2: index })
+      model.transformRescale(index)
       # Need to append new column name and connect new column with existing column
       model.columns(cols)
       link_transform_column(index, transform_col.index)

--- a/interface/components/transform/index.coffee
+++ b/interface/components/transform/index.coffee
@@ -16,6 +16,9 @@ ko.components.register "tf-transform",
     @transform_index = model.show_transform
     transform_columns = model.transform_columns
 
+    @k = ko.observable 1
+    @invalid = false
+
     # Check if transform popup should render
     @active = ko.computed ( ) => @transform_index() != undefined
 
@@ -40,6 +43,9 @@ ko.components.register "tf-transform",
     @close = ( ) ->
       model.show_transform(undefined)
 
+    @change_k = ( ) ->
+      @invalid = !@k() || isNaN(@k())
+
     @transform_log = ( index ) ->
       transform_col = gen_column(
         Transformation.LOG,
@@ -53,21 +59,24 @@ ko.components.register "tf-transform",
       link_transform_column(index, transform_col.index)
       @close()
     
-    @k_order_diff = ( index, k = 1 ) ->
-      transform_col = gen_column(
-        Transformation.K_ORDER_DIFFERENCE,
-        index
-      )
-      cols = columns()
-      cols.push(transform_col)
-      model.kOrderTransform({
-        "#{index}": true,
-        "#{k}": true
-      })
-      # Need to append new column name and connect new column with existing column
-      model.columns(cols)
-      link_transform_column(index, transform_col.index)
-      @close()
+    @k_order_diff = ( index ) ->
+      if !@invalid
+        transform_col = gen_column(
+          Transformation.K_ORDER_DIFFERENCE,
+          index
+        )
+        cols = columns()
+        cols.push(transform_col)
+        model.kOrderTransform({
+          index: index,
+          k: @k()
+        })
+        # Need to append new column name and connect new column with existing column
+        model.columns(cols)
+        link_transform_column(index, transform_col.index)
+        @k(1)
+        @invalid = false
+        @close()
 
     @standardize = ( index ) ->
       transform_col = gen_column(

--- a/interface/components/transform/index.coffee
+++ b/interface/components/transform/index.coffee
@@ -22,7 +22,7 @@ ko.components.register "tf-transform",
     # Check if transform popup should render
     @active = ko.computed ( ) => @transform_index() != undefined
 
-    gen_column = ( label, index ) ->
+    gen_column = ( label, index, k = undefined ) ->
       cols = columns()
       ncols = cols.length
       transform_col = cols[index]
@@ -31,7 +31,8 @@ ko.components.register "tf-transform",
       return {
         name: transform_name,
         index: transform_index,
-        label: label
+        label: label,
+        k: k,
       }
 
     # Function updates model transform_columns and associate the transform column to original column
@@ -63,7 +64,8 @@ ko.components.register "tf-transform",
       if !@invalid
         transform_col = gen_column(
           Transformation.K_ORDER_DIFFERENCE,
-          index
+          index,
+          Number(@k())
         )
         cols = columns()
         cols.push(transform_col)

--- a/interface/components/transform/index.pug
+++ b/interface/components/transform/index.pug
@@ -1,17 +1,21 @@
 .background(data-bind="css:{active:active}, click:close")
 .transform(data-bind="css:{active:active}")
   p(text="Transform Column")
-  div.option-wrapper
-    button.option(
-      data-bind="click:function(){transform_log(transform_index())}"
-    ) Log
-    input.custom(data-bind="textInput:k,event:{keyup:change_k},css:{invalid:invalid}")
-    button.option(
-      data-bind="click:function(){k_order_diff(transform_index())}"
-    ) K-Order Difference
-    button.option(
-      data-bind="click:function(){standardize(transform_index())}"
-    ) Standardize
-    button.option(
-      data-bind="click:function(){rescale(transform_index())}"
-    ) Rescale
+  div.container
+    div.option-wrapper
+      button.option(
+        data-bind="click:function(){transform_log(transform_index())}"
+      ) Log
+    div.option-wrapper.k-order
+      input.custom(data-bind="textInput:k,event:{keyup:change_k},css:{invalid:invalid}")
+      button.option(
+        data-bind="click:function(){k_order_diff(transform_index())}"
+      ) K-Order Difference
+    div.option-wrapper
+      button.option(
+        data-bind="click:function(){standardize(transform_index())}"
+      ) Standardize
+    div.option-wrapper
+      button.option(
+        data-bind="click:function(){rescale(transform_index())}"
+      ) Rescale

--- a/interface/components/transform/index.pug
+++ b/interface/components/transform/index.pug
@@ -5,6 +5,7 @@
     button.option(
       data-bind="click:function(){transform_log(transform_index())}"
     ) Log
+    input.custom(data-bind="textInput:k,event:{keyup:change_k},css:{invalid:invalid}")
     button.option(
       data-bind="click:function(){k_order_diff(transform_index())}"
     ) K-Order Difference

--- a/interface/components/transform/index.pug
+++ b/interface/components/transform/index.pug
@@ -5,9 +5,9 @@
     button.option(
       data-bind="click:function(){transform_log(transform_index())}"
     ) Log
-    //- button.option(
-    //-   data-bind="click:function(){k_order_diff(transform_index())}"
-    //- ) K-Order Difference
+    button.option(
+      data-bind="click:function(){k_order_diff(transform_index())}"
+    ) K-Order Difference
     //- button.option(
     //-   data-bind="click:function(){studentize(transform_index())}"
     //- ) Studentize

--- a/interface/components/transform/index.pug
+++ b/interface/components/transform/index.pug
@@ -8,9 +8,9 @@
     button.option(
       data-bind="click:function(){k_order_diff(transform_index())}"
     ) K-Order Difference
-    //- button.option(
-    //-   data-bind="click:function(){studentize(transform_index())}"
-    //- ) Studentize
-    //- button.option(
-    //-   data-bind="click:function(){normalize(transform_index())}"
-    //- ) Normalize
+    button.option(
+      data-bind="click:function(){standardize(transform_index())}"
+    ) Standardize
+    button.option(
+      data-bind="click:function(){rescale(transform_index())}"
+    ) Rescale

--- a/interface/components/transform/index.styl
+++ b/interface/components/transform/index.styl
@@ -36,3 +36,16 @@ tf-transform
     display flex
     justify-content center
     align-items center
+
+  & input.custom
+    cursor text
+    font-size 12pt
+    width 50px
+    background rgba(black, 0.1)
+    box-shadow 0 0 0 2px rgba(black, 0.3)
+    padding 2px 12px
+    margin 4px
+    border-radius 1000px
+    transition 300ms
+    &.invalid
+      box-shadow 0 0 2px red

--- a/interface/components/transform/index.styl
+++ b/interface/components/transform/index.styl
@@ -29,6 +29,19 @@ tf-transform
   .active
     display block
 
+  .container
+    width 100%
+    height: 100%
+    display flex
+    flex-direction row
+    justify-content space-between
+    align-items flex-start
+    flex-wrap wrap
+  
+  .option-wrapper
+    width fit-content
+    height fit-content
+
   .option
     width 75px
     height 50px
@@ -36,6 +49,11 @@ tf-transform
     display flex
     justify-content center
     align-items center
+
+  .k-order
+    display flex
+    align-items center
+    justify-content flex-start
 
   & input.custom
     cursor text

--- a/interface/components/transform/label.json
+++ b/interface/components/transform/label.json
@@ -1,14 +1,14 @@
 {
   "LOG" : "log",
   "K_ORDER_DIFFERENCE" : "K order difference",
-  "STUDENTIZED" : "studentized",
-  "NORMALIZED" : "normalized",
+  "STANDARDIZE" : "Standardize",
+  "RESCALE" : "Rescale",
 
   "Transform": {
     "delete": 0,
     "log": 1,
     "k_order_diff": 2,
-    "studentize": 3,
-    "normalize": 4
+    "standardize": 3,
+    "rescale": 4
   }
 }


### PR DESCRIPTION
## Changes
  - Fix a bug with the previous model of log transform
  - Support object 2 object conversion from model.coffee to adapter.coffee
  - Support K-Order diff, Standardize, and Normalize