### PR TITLE
Fix Cumulative Distribution Plot

### DIFF
--- a/interface/components/cumulative-distribution/index.coffee
+++ b/interface/components/cumulative-distribution/index.coffee
@@ -40,7 +40,7 @@ ko.components.register "tf-cumulative-distribution",
     @close = ( ) ->
       model.show_cumulative_distribution undefined
 
-    @bucket_size = ko.observable(10);
+    @bucket_size = ko.observable(10)
 
     @charthtml = ko.computed () =>
       unless @active()
@@ -183,6 +183,18 @@ ko.components.register "tf-cumulative-distribution",
     @column_index.subscribe ( next ) =>
       if next then adapter.unsubscribeToChanges()
       else adapter.subscribeToChanges()
+      if @active()
+        if (@values().length)
+          # Use Sturges' formula to determine the optimal number of buckets
+          # k = number of buckets (bins)
+          k = Math.ceil(Math.log2(@values().length)) + 1
+          numUniqueValues = @values().filter((val, i, arr) ->
+                              return arr.indexOf(val) == i
+                            ).length
+          if numUniqueValues < k
+            @bucket_size numUniqueValues 
+          else
+            @bucket_size k 
 
     @inc = ( ) -> @bucket_size @bucket_size() + 1
     @dec = ( ) -> @bucket_size ((@bucket_size() - 1) || 1)

--- a/interface/components/cumulative-distribution/index.coffee
+++ b/interface/components/cumulative-distribution/index.coffee
@@ -47,28 +47,34 @@ ko.components.register "tf-cumulative-distribution",
         return ""
 
       sorted = @values().filter((x) => !isNaN(x)).sort((a, b) => a - b)
-      min = sorted[0]
-      max = sorted[sorted.length - 1] + 1
-      buckets = Array(@bucket_size()).fill(0)
-      bucket_width = (max - min) / @bucket_size()
-      sorted.forEach((x) => buckets[Math.floor((x - min) / bucket_width)]++)
-      n = buckets.reduce (t, s) -> t + s
-      last = 0
-      for i in [0...buckets.length]
-        buckets[i] += last
-        last = buckets[i]
-        buckets[i] /= n
+      count = {}
 
-      labels = Array(@bucket_size()).fill(0).map((x, index) => Math.ceil(index * bucket_width) + min)
+      for i in [0..sorted.length-1]
+        if !count[sorted[i]]
+          count[sorted[i]] = 0
+        ++count[sorted[i]]
+
+      console.log(count)
+      # console.log(Object.values(count))
+      # console.log(Object.keys(count))
+      cumulative_pct = Object.values(count)
+      n = Object.values(count).reduce (t, s) -> t + s
+      last = 0
+      for i in [0..cumulative_pct.length-1]
+        cumulative_pct[i] += last
+        last = cumulative_pct[i]
+        cumulative_pct[i] /= n
+      console.log(cumulative_pct)
 
       # global varible 'chart' can be accessed in download function
       global.chart = c3.generate
         bindto: "#cumulative-distribution"
         data:
+          type: "scatter"
           x: "x"
           columns: [
-            ["x"].concat(labels),
-            [@column_name()].concat(buckets)
+            ["x"].concat(Object.keys(count)),
+            ["y"].concat(cumulative_pct)
           ]
         size:
           height: 370
@@ -76,6 +82,7 @@ ko.components.register "tf-cumulative-distribution",
         axis:
           x:
             tick:
+              count: 10
               format: d3.format('.3s')
           y:
             min: 0

--- a/interface/components/cumulative-distribution/index.coffee
+++ b/interface/components/cumulative-distribution/index.coffee
@@ -52,7 +52,6 @@ ko.components.register "tf-cumulative-distribution",
       buckets = Array(@bucket_size()).fill(0)
       bucket_width = (max - min) / @bucket_size()
       sorted.forEach((x) => buckets[Math.floor((x - min) / bucket_width)]++)
-      
       n = buckets.reduce (t, s) -> t + s
       last = 0
       for i in [0...buckets.length]
@@ -79,6 +78,12 @@ ko.components.register "tf-cumulative-distribution",
             tick:
               format: d3.format('.3s')
           y:
+            min: 0
+            max: 1
+            # y axis has a default padding value
+            padding:
+              top: 0
+              bottom: 0
             tick:
               format: d3.format('%')
         legend:
@@ -127,12 +132,26 @@ ko.components.register "tf-cumulative-distribution",
         e.style.fill = "none"
 
       svg_element.style.backgroundColor = "white"
+      tick = svg_element.querySelectorAll ".tick"
+      num_arr = Array(tick.length).fill(0).map((x, y) => y)
+
+      for num in num_arr
+        # use transform property to check if the SVG element is on the top position of y axis
+        transform_y_val = (getComputedStyle(tick[num]).getPropertyValue('transform').replace(/^matrix(3d)?\((.*)\)$/,'$2').split(/, /)[5])*1
+        if transform_y_val == 1
+          text = tick[num].getElementsByTagName("text")
+          # stop the loop once the SVG element on the top position of y axis is found
+          break
+
+      original_y = text[0].getAttribute "y"
+      text[0].setAttribute "y", original_y + 3
       
       xml = new XMLSerializer().serializeToString svg_element
       data_url = "data:image/svg+xml;base64," + btoa xml
 
       # Reset to original values
       svg_element.style.padding = null
+      text[0].setAttribute "y", original_y
       svg_element.setAttribute "height", original_height
       svg_element.setAttribute "width", original_width
       svg_element.style.backgroundColor = null

--- a/interface/components/cumulative-distribution/index.coffee
+++ b/interface/components/cumulative-distribution/index.coffee
@@ -43,7 +43,7 @@ ko.components.register "tf-cumulative-distribution",
     @bucket_size = ko.observable(10)
 
     @charthtml = ko.computed () =>
-      unless @active()
+      if !@active() || @values().length == 0
         return ""
 
       sorted = @values().filter((x) => !isNaN(x)).sort((a, b) => a - b)

--- a/interface/components/cumulative-distribution/index.pug
+++ b/interface/components/cumulative-distribution/index.pug
@@ -1,7 +1,5 @@
 .background(data-bind="css:{active:active}, click:close")
 .cumulative-distribution(data-bind="css:{active:active}")
   span.title(data-bind="text: column_name() + ' Cumulative Distribution'")
-  a.right(data-bind="click:inc") + Bucket
-  a.left(data-bind="click:dec") - Bucket
   a.download(data-bind="click:download") Download
   <div id="cumulative-distribution" data-bind="html: charthtml"></div>

--- a/interface/components/cumulative-distribution/index.styl
+++ b/interface/components/cumulative-distribution/index.styl
@@ -19,7 +19,7 @@ tf-cumulative-distribution
     margin-top -210px
     margin-left -310px
     width 615px
-    height 420px
+    height 450px
     background #fff
     border 1px solid #e9ebed
     padding 10px
@@ -31,22 +31,6 @@ tf-cumulative-distribution
     display: block;
     text-align: center;
 
-  .right, .left
-    background #27ae60
-    color #fff
-    padding 2px 12px
-    border-radius 2px
-    font-size 12pt
-    margin-left 10px
-    top 8px
-    position absolute
-
-  .right
-    right 8px
-
-  .left
-    left 8px
-  
   .download
     background #1a8cff
     color #fff

--- a/interface/components/cumulative-distribution/index.styl
+++ b/interface/components/cumulative-distribution/index.styl
@@ -18,7 +18,7 @@ tf-cumulative-distribution
     left 50%
     margin-top -210px
     margin-left -310px
-    width 600px
+    width 615px
     height 420px
     background #fff
     border 1px solid #e9ebed


### PR DESCRIPTION
### Changes
- Fix background width
- Use the data set points as the X axis and cumulative percentages as the Y Axis (scatter plot)
- Force to start Y-axis always with zero 
- Use transform property to find the tick on the top position of y axis and make sure the tick is not cut off in the downloaded plot

### Demo
![chart - 2019-04-15T160526 661](https://user-images.githubusercontent.com/26676864/56161745-54917f80-5f98-11e9-9b3c-fae141f546b0.png)
