### PR TITLE
Disable Sensitivity on Timeseries Models

### DIFF
--- a/interface/components/grid/index.coffee
+++ b/interface/components/grid/index.coffee
@@ -102,6 +102,9 @@ ko.components.register "tf-grid",
         model.show_qqplot("ImportanceRatio_"+index.toString())
         model.data_plotted(@table)
 
+    @istimeseries = () ->
+      return model.timeseries
+
     @sensitivity = ( index ) ->
       model.show_sensitivity( index )
     

--- a/interface/components/grid/index.pug
+++ b/interface/components/grid/index.pug
@@ -41,6 +41,7 @@ table.grid
             | QQ Plot
           span.mark(data-bind="click:function(){xyplot($index() + 1)}")
             | XY Plot
+          // ko ifnot: istimeseries()
           // ko ifnot: hasSensitivity($index())
           span.mark(data-bind="click:function(){sensitivity($index())}")
             | Show Sensitivity
@@ -56,6 +57,7 @@ table.grid
           // ko if: hasImportanceRatio($index())
           span.mark(data-bind="click:function(){deleteImportanceRatio($index(),'column')}")
             | Hide Importance Ratio
+          // /ko
           // /ko
           // ko if: table == "fit" && $index() !== dependent() && !isHidden($index())
           span.mark(data-bind="click:function(){showHideColumn(true, $index())}")


### PR DESCRIPTION
Current sensitivity and importance ratio calculation is not applicable to time series models. Suppress these two statistics for time series models.